### PR TITLE
Rework inline formatting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 requires-python = ">=3.10"
-dependencies = ["dominate==2.8.0"]
+dependencies = ["dominate==2.8.0", "intervaltree==3.1.0"]
 
 [project.optional-dependencies]
 dev = ["pytest==7.4.2", "prettyprinter==0.18.0"]

--- a/src/npf_renderer/format/inline.py
+++ b/src/npf_renderer/format/inline.py
@@ -1,5 +1,4 @@
 import itertools
-import queue
 from typing import Sequence, Callable
 
 import dominate.tags
@@ -22,22 +21,23 @@ class _OperationsIterator(helpers.CursorIterator):
 
     def __init__(self, operations):
         super().__init__(operations)
-        self.next_start = None
-        self.next_end = None
+
+        if peek := self.peek():
+            self.next_start = peek.start
+            self.next_end = peek.end
+        else:
+            self.next_start = None
+            self.next_end = None
 
     def next(self):
         """Extends next() to store next_start and next_end"""
         status = super().next()
-        if status:  # Save a bit of performance.
-            if peek := self.peek():
-                self.next_start = peek.start
-                self.next_end = peek.end
-
-        if not status:
+        if peek := self.peek():
+            self.next_start = peek.start
+            self.next_end = peek.end
+        else:
             self.next_start = None
             self.next_end = None
-
-        return status
 
 
 class InlineFormatter(helpers.CursorIterator):
@@ -54,21 +54,16 @@ class InlineFormatter(helpers.CursorIterator):
         # Each inline format is going to be called an "operation"
 
         # Returns a list of operations sorted by the start (ascending) and end (descending) of each
-        operations = sorted(inline_formats, key=lambda format_op: (format_op.start, -format_op.end))
-        self._ops = _OperationsIterator(operations)
+        self._ops = _OperationsIterator(inline_formats)
 
         self.url_handler = url_handler
 
         self._accumulator = []
 
-        # Temporarily latches onto operations that needs to be completed
-        # in the next context for whatever reasons
-        self._priority_operation_queue = queue.Queue()
-
     @property
-    def _reached_new_format_operation(self):
+    def _reached_next_format_operation(self):
         """Check if we have reached the start of a new format operation"""
-        if self.cursor in (self._ops.current.start, self._ops.next_start):
+        if self.cursor == self._ops.next_start:
             return True
         else:
             return False
@@ -81,122 +76,9 @@ class InlineFormatter(helpers.CursorIterator):
 
         return status
 
-    def _perform_operation(self, current_tag, till):
-        """Performs a formatting option till the specified ending index
-
-        Arguments:
-            current_tag: The tag in which further nested tags and text gets applied/added to
-            till: An index at which the perform_operation method should break and stop.
-
-        """
-
-        # If this stops then that means either a new formatting section begun (likely while in the midst of ours,
-        # aka an overlapping region) or we've reached the end of the string, or the end of the current formatting
-        # section (the till argument).
-        while not self._reached_new_format_operation and not self._at_end and (self.cursor < till):
-
-            # Handle overlapping regions that starts at the same location as us but end differently.
-            #
-            # We don't have to check for peek() also having the same end as those are already condensed into
-            # a single operation during the parsing stage.
-            if self._ops.current.start == self._ops.next_start:
-                # If we (operation or till-wise) still last longer than the next operation
-                # then they'll be handled under us.
-                while till > self._ops.next_end:
-                    self._ops.next()
-                    self._route_operations(self._ops.current.end, current_tag)
-
-                    # Obviously we can break once our start differs again or we've reached the end
-                    if (self._ops.current.start != self._ops.next_start) or self._ops._at_end:
-                        break
-
-            self.next()
-
-        # Have we reached our stopping point? (Doesn't matter whether it's the end of our current op or not)
-        # If so we dump into the current tag and let whoever called us handle what comes next or
-        # what remains of us if any.
-        if (self.cursor >= till) or self._at_end:
-            current_tag.add(dominate.util.text("".join(self._accumulator)))
-            self._accumulator = []
-
-            # Get next operation if we are completely finished
-            if till == self._ops.current.end:
-                self._ops.next()
-
-            return
-
-        # It should be a new formatting section if we've got this far.
-        assert self._reached_new_format_operation
-
-        # So we're going to push all of our accumulated letters to the current tag
-        # to get ready for the overlapping section (The next operation will be starting while we're still in the midst
-        # of ours.)
-        current_tag.add(dominate.util.text("".join(self._accumulator)))
-        self._accumulator = []
-
-        try:
-            self.next()
-
-            # If our current operation lasts longer than when this method is supposed to end,
-            # and a new formatting operation is starting then we need to make sure that this current operation actually
-            # gets remembered and finished once the new formatting section has been taken care of.
-
-            # Without this another formatting section in the midst of the one that's about to start might be
-            # reached, and we'll lose access to the current formatting section forever.
-
-            operation_latch = None
-            if till < self._ops.current.end:
-                operation_latch = self._ops.current
-
-            self._ops.next()
-
-            # Do we go on for longer than the (now) current operation?
-            #
-            # If so we'll take care of the current operation first, and any subsequent operations that are still
-            # overlapping with us.
-            if till > self._ops.current.end:
-                while till > self._ops.current.end and not self._ops._at_end:
-                    self._route_operations(self._ops.current.end, parent_tag=current_tag)
-
-                # As the above function breaks as soon as we reach the end of the operations list
-                # there's a few considerations we need to take
-                if self._ops._at_end:
-                    # First we need to finish up the current operation if we aren't there yet
-                    if self.cursor < self._ops.current.end:
-                        self._route_operations(self._ops.current.end, parent_tag=current_tag)
-
-                    # Since there's no more new operations to consume, the only operations left to finish is our own.
-                    # Therefore, we shall advance up until till (either our stopping point or end of our operation)
-                    # and then append the result to current_tag and let whoever called us handle the remaining stuff if
-                    # any.
-                    #
-                    # However, sometimes the ending index of an operation (till) is out of bounds. And if we've already reached
-                    # the end of the string then there is nothing left to do.
-                    while (self.cursor < till) and not self._at_end:
-                        self.next()
-
-                    current_tag.add(dominate.util.text("".join(self._accumulator)))
-                    self._accumulator = []
-                else:
-                    # Finish remaining characters until till
-                    self._perform_operation(current_tag=current_tag, till=till)
-
-            else:
-                self._route_operations(till, parent_tag=current_tag)
-                # Read comment above. Dump in priority queue to get fulfilled as soon as we reach route_operations()
-                # again, which should be to fulfill the remainder of the current op.
-                if operation_latch and till < operation_latch.end:
-                    self._priority_operation_queue.put(operation_latch)
-
-        except StopIteration:
-            pass
-
-    def _get_tag_of_operation(self, operation):
-        """Maps an inline formatting operation to corresponding HTML tags
-
-        This should probably not be used directly. Instead, use _calculate_operation_tags() which calls this method.
-        """
-        match operation.type:
+    def _get_tag_of_operation(self, instruction):
+        """Maps an inline formatting instruction to a corresponding HTML tag"""
+        match instruction.type_:
             case objects.inline.FMTTypes.BOLD:
                 return dominate.tags.b(cls="inline-bold")
 
@@ -209,14 +91,14 @@ class InlineFormatter(helpers.CursorIterator):
             case objects.inline.FMTTypes.SMALL:
                 return dominate.tags.small(cls="inline-small")
 
+            case objects.inline.FMTTypes.COLOR:
+                return dominate.tags.span(style=f"color: {instruction.hex};", cls="inline-color")
+
             case objects.inline.FMTTypes.LINK:
-                return dominate.tags.a(href=self.url_handler(operation.url), cls="inline-link")
+                return dominate.tags.a(href=self.url_handler(instruction.url), cls="inline-link")
 
             case objects.inline.FMTTypes.MENTION:
-                return dominate.tags.a(href=self.url_handler(operation.blog_url), cls="inline-mention")
-
-            case objects.inline.FMTTypes.COLOR:
-                return dominate.tags.span(style=f"color: {operation.hex};", cls="inline-color")
+                return dominate.tags.a(href=self.url_handler(instruction.blog_url), cls="inline-mention")
 
     def _calculate_operation_tags(self, operation):
         """Converts a specific operation to corresponding HTML tags
@@ -239,13 +121,13 @@ class InlineFormatter(helpers.CursorIterator):
 
             More often than not the working_tag is exactly the same as the root_tag
         """
-        if not isinstance(operation.type, list):
-            working_tag = self._get_tag_of_operation(operation)
+        if len(operation.instructions) == 1:
+            working_tag = self._get_tag_of_operation(operation.instructions[0])
             root_tag = working_tag
         else:
             nested_child_tags = []
 
-            for ops in operation.type:
+            for ops in operation.instructions:
                 nested_child_tags.append(self._get_tag_of_operation(ops))
 
             for child_tag_one, child_tag_two in itertools.pairwise(nested_child_tags):
@@ -259,158 +141,32 @@ class InlineFormatter(helpers.CursorIterator):
 
         return working_tag, root_tag
 
-    def _perform_priority_operation(self, till, parent_tag):
-        """Fetches and performs a priority operation from the priority queue
-
-        The priority operation is an operation that wasn't able to get completed in the last context due to the
-        operations iterator advancing past while also having its current context end before reaching the ending point.
-
-        See _perform_operation() for more details on how this method works.
-        """
-
-        # Priority queue handling. If something exists within it is likely that the priority operation wasn't able to
-        # be completed in the last context due to the operator iterator advancing, and also having reached the till
-        # stopping point.
-        #
-        # For more information see the innards of self.perform_operation
-        operation = self._priority_operation_queue.get()
-        operation_tag, attachment_tag = self._calculate_operation_tags(operation)
-
-        if operation.start <= self._ops.current.end and self._ops.current.start <= operation.end:
-            # If the priority operation ends after the currently selected operation does then we will finish that
-            # first. Otherwise, vise versa.
-            if operation.end <= self._ops.current.end:
-                # Either run until the till value or the end of the priority operation depending on which ends first
-                if till < operation.end:
-                    self._route_operations(till, parent_tag=operation_tag)
-
-                    # Latch current operation to be handled the next time we reach self.route_operation
-                    # since our current context needs to end as we've reached till, and we still haven't reached
-                    # operation.end
-                    self._priority_operation_queue.put(operation)
-                else:
-                    self._route_operations(operation.end, parent_tag=operation_tag)
-
-                # If somehow we've neither hit the end of the priority operation, or even till then we'll
-                # need to finish off the remainders
-                if self.cursor < operation.end and self.cursor < till:
-                    # Of course, we might actually have to just run until the till value if it ends before we do
-                    if till < operation.end:
-                        self._route_operations(till, parent_tag=operation_tag)
-                        # So we also latch onto the priority operation as our current context is ending forcing us
-                        # to finish in the next context instead
-                        self._priority_operation_queue.put(operation)
-                    else:
-                        self._route_operations(operation.end, parent_tag=operation_tag)
-
-                elif self.cursor < till == self._ops.current.end:
-                    # If we have ended, but we still haven't reached the till value then obviously it goes on for
-                    # longer than the priority operation. As such we need to finish that.
-
-                    # We just need to make sure that we are working in the same context as what the till
-                    # operation should be. It can be checked by a comparison of (till == self.ops.current.end)
-
-                    parent_tag.add(attachment_tag)
-
-                    return self._route_operations(self._ops.current.end, parent_tag=parent_tag)
-            else:
-                # Since we (the priority operation) last longer than the currently selected operation, we're going
-                # to finish it (and any other operations that remains inside us) until we've reached our breaking
-                # point of till
-                while till < operation.end and not self._ops._at_end:
-                    self._route_operations(self._ops.current.end, parent_tag=operation_tag)
-
-                if self._ops._at_end:
-                    if self.cursor < till:
-                        self._route_operations(till, parent_tag=operation_tag)
-
-                    # We've already processed until the till, and now we're also at the end of the operations list.
-                    # There shouldn't be anything more to do. We will directly process until the end of the current
-                    # priority operation
-                    while self.cursor < operation.end:
-                        self.next()
-
-                    operation_tag.add(dominate.util.text("".join(self._accumulator)))
-                    self._accumulator = []
-
-                else:
-                    # Finish remaining if applicable
-                    if self.cursor < till:
-                        self._route_operations(till, parent_tag=operation_tag)
-
-                    # If we've reached the end of our current context and still haven't completed the priority
-                    # operation then we'll just do it next time we reach self.route_operations
-                    if till < operation.end:
-                        self._priority_operation_queue.put(operation)
-        else:
-            # Not Possible
-            raise RuntimeError("Priority operation failed check. Shouldn't be possible")
-
-        if self._at_end:
-            return
-
-        return parent_tag.add(attachment_tag)
-
-    def _route_operations(self, till, parent_tag=None):
-        """Delegate formatting to specific tags
-
-        Adds result to the given parent_tag or self.parent_tag when unset
-        """
-        if self._at_end:
-            return
-
-        if not parent_tag:
-            parent_tag = self.parent_tag
-
-        if not self._priority_operation_queue.empty():
-            return self._perform_priority_operation(till, parent_tag)
-
-        working_tag, attachment_tag = self._calculate_operation_tags(self._ops.current)
-        self._perform_operation(current_tag=working_tag, till=till)
-
-        parent_tag.add(attachment_tag)
+    def dump_accumulator_to_tag(self, tag):
+        """Dumps and clears everything from the accumulator to the given tag as text."""
+        tag.add(dominate.util.text(''.join(self._accumulator)))
+        self._accumulator = []
 
     def format(self):
         """Returns a formatted string formatted with the given inline operations"""
 
-        # Begin operations iteration
-        self._ops.next()
-
         while not self._at_end:
-            if self._reached_new_format_operation:
+            while self._reached_next_format_operation:
+                self._ops.next()
+
                 # Dump the unformatted text we've been collecting into the parent
-                self.parent_tag.add(dominate.util.text(''.join(self._accumulator)))
-                self._accumulator = []
+                self.dump_accumulator_to_tag(self.parent_tag)
 
-                till = self._ops.current.end
+                # Handle operation
 
-                # Consumes the next character, so we don't trigger
-                # new_format_section again
-                self.next()
-                self._route_operations(till)
-
-                # Check for remaining characters to format in the current cursor position
-                while not self._at_end and (
-                    self._ops.current.start <= self.cursor < (till := self._ops.current.end)
-                ):
+                working_tag, root_tag = self._calculate_operation_tags(self._ops.current)
+                while self.cursor != self._ops.current.end and not self._at_end:
                     self.next()
-                    self._route_operations(till)
 
-            # Handle remaining priority queue
-            if not self._priority_operation_queue.empty():
-                # Inefficient way to get a till value.
-                operation = self._priority_operation_queue.get()
-                till = operation.end
-                self._priority_operation_queue.put(operation)
-
-                # Will reaccess the priority operator queue inside
-                self._route_operations(till)
+                self.dump_accumulator_to_tag(working_tag)
+                self.parent_tag.add(root_tag)
 
             self.next()
 
-        # Leftovers
-        if self._accumulator:
-            self.parent_tag.add(dominate.util.text("".join(self._accumulator)))
-            self._accumulator = []
+        self.dump_accumulator_to_tag(self.parent_tag)
 
         return self.parent_tag

--- a/src/npf_renderer/objects/inline.py
+++ b/src/npf_renderer/objects/inline.py
@@ -1,7 +1,7 @@
 """Objects storing data for inline formatting used in NPF's Text Content Block"""
 
 import enum
-from typing import NamedTuple, Union
+from typing import NamedTuple, Union, Sequence
 
 
 class FMTTypes(enum.Enum):
@@ -13,51 +13,48 @@ class FMTTypes(enum.Enum):
     MENTION = 5
     COLOR = 6
 
-    TOTAL_OVERLAP_PACKAGE = 7
 
-
-class Standard(NamedTuple):
+class Instruction(NamedTuple):
     """A tuple storing data on various inline formatting options"""
-    type: FMTTypes
-    start: int
-    end: int
+    type_: FMTTypes
+
+    def __lt__(self, other):
+        return self.type_.value < other.type_.value
 
 
-class Link(NamedTuple):
+class LinkInstruction(NamedTuple):
     """A tuple storing data on formatting an inline link"""
-    type: FMTTypes
-    start: int
-    end: int
+    type_: FMTTypes
     url: str
 
+    def __lt__(self, other):
+        return self.type_.value < other.type_.value
 
-class Mention(NamedTuple):
+class MentionInstruction(NamedTuple):
     """A tuple storing data on formatting an inline mention of a blog"""
-    type: FMTTypes
-    start: int
-    end: int
+    type_: FMTTypes
 
     blog_name: str
     blog_url: str
     blog_uuid: str
 
+    def __lt__(self, other):
+        return self.type_.value < other.type_.value
 
-class Color(NamedTuple):
+
+class ColorInstruction(NamedTuple):
     """A tuple storing data on formatting colored text"""
-    type: FMTTypes
-    start: int
-    end: int
+    type_: FMTTypes
     hex: str
 
+    def __lt__(self, other):
+        return self.type_.value < other.type_.value
 
-class TotalOverlaps(NamedTuple):
-    """A tuple storing data on formatting operations that overlaps from start to finish
 
-    This allows for easily constructing the nested HTML tags that comes out of this.
-    """
-    type: list[Union[Standard, Link, Mention, Color]]
+class StyleInterval(NamedTuple):
     start: int
     end: int
+    instructions: Sequence[Union[Instruction, LinkInstruction, MentionInstruction, ColorInstruction]]
 
 
-INLINE_FMT_TYPES = Union[Standard, Link, Mention, Color, TotalOverlaps]
+INLINE_FMT_TYPES = Union[Instruction, LinkInstruction, MentionInstruction, ColorInstruction]

--- a/tests/image_block/image_block_test_data.py
+++ b/tests/image_block/image_block_test_data.py
@@ -456,11 +456,15 @@ image_block_with_app_attribution = (
         objects.text_block.TextBlock(
             text="Check out my commission from author! Please follow them here https://twitter.com/example",
             inline_formatting= [
-                objects.inline.Link(
-                    type=objects.inline.FMTTypes.LINK,
+                objects.inline.StyleInterval(
                     start=61,
                     end=88,
-                    url="https://twitter.com/example"
+                    instructions=[
+                        objects.inline.LinkInstruction(
+                            type_=objects.inline.FMTTypes.LINK,
+                            url="https://twitter.com/example"
+                        )
+                    ],
                 )
             ]
         ),

--- a/tests/inline/format_only_inline_test_data.py
+++ b/tests/inline/format_only_inline_test_data.py
@@ -41,6 +41,7 @@ connected_back_to_back_format_test = (
     ),
 )
 
+
 back_to_back_format_test = (
     [
         {
@@ -81,6 +82,7 @@ back_to_back_format_test = (
     ),
 )
 
+
 long_space_in_between_format_test = (
     [
         {
@@ -112,6 +114,7 @@ long_space_in_between_format_test = (
     ),
 )
 
+
 second_has_lower_end_index_test = (
     [
         {
@@ -128,18 +131,17 @@ second_has_lower_end_index_test = (
         tags.blockquote(
             tags.span(
                 "The ",
-                tags.span(
-                    "brown ",
-                    tags.b(
+                tags.span("brown ", cls="inline-color", style="color: #964B00;"),
+                tags.b(
+                    tags.span(
                         "fox",
-                        cls="inline-bold"
+                        cls="inline-color",
+                        style="color: #964B00;"
                     ),
-                    " jumped over",
-                    cls="inline-color",
-                    style="color: #964B00;",
+                    cls="inline-bold",
                 ),
+                tags.span(" jumped over", cls="inline-color", style="color: #964B00;"),
                 " the lazy dog",
-
                 cls="inline-formatted-content"
             ),
             cls="text-block indented inline-formatted-block",
@@ -148,6 +150,7 @@ second_has_lower_end_index_test = (
         cls="post-body"
     )
 )
+
 
 second_has_lower_end_index_test_2 = (
     [
@@ -166,21 +169,37 @@ second_has_lower_end_index_test_2 = (
         tags.blockquote(
             tags.span(
                 "The ",
-                tags.span(
-                    "br",
-                    tags.small(
+                tags.span("br", cls="inline-color", style="color: #964B00;"),
+                tags.small(
+                    tags.span(
                         "own ",
-                        tags.b(
-                            "fox",
-                            cls="inline-bold"
-                        ),
-                        " ",
-                        cls="inline-small",
+                        cls="inline-color",
+                        style="color: #964B00;"
                     ),
-                    "jumped over",
-                    cls="inline-color",
-                    style="color: #964B00;",
+                    cls="inline-small", 
                 ),
+                tags.b(
+                    tags.small(
+                        tags.span(
+                            "fox",
+                        cls="inline-color", 
+                        style="color: #964B00;"
+                        ),
+                        cls="inline-small"
+                    ),
+                    cls="inline-bold"
+                ),
+
+                tags.small(
+                    tags.span(
+                        " ",
+                        cls="inline-color",
+                        style="color: #964B00;"
+                    ),
+                    cls="inline-small"
+                ),
+
+                tags.span("jumped over", cls="inline-color", style="color: #964B00;"),
                 " the lazy dog",
 
                 cls="inline-formatted-content"
@@ -192,6 +211,7 @@ second_has_lower_end_index_test_2 = (
         cls="post-body"
     )
 )
+
 
 overlapping_same_area_test_data = (
     [
@@ -214,26 +234,26 @@ overlapping_same_area_test_data = (
         tags.blockquote(
             tags.span(
                 "The ",
-                tags.span(
-                    tags.a(
-                        tags.b(
-                            tags.s(
-                                tags.i(
-                                    tags.small(
+                tags.b(
+                    tags.i(
+                        tags.s(
+                            tags.small(
+                                tags.a(
+                                    tags.span(
                                         "hypersonic brown fox",
-                                        cls="inline-small"
+                                        cls="inline-color",
+                                        style="color: #964B00;"
                                     ),
-                                    cls="inline-italics"
+                                    href="https://www.youtube.com/watch?v=jofNR_WkoCE",
+                                    cls="inline-link",
                                 ),
-                                cls="inline-strikethrough"
+                                cls="inline-small"
                             ),
-                            cls="inline-bold"
+                            cls="inline-strikethrough"
                         ),
-                        href="https://www.youtube.com/watch?v=jofNR_WkoCE",
-                        cls="inline-link"
+                        cls="inline-italics"
                     ),
-                    cls="inline-color",
-                    style="color: #964B00;"
+                    cls="inline-bold"
                 ),
                 " jumped over the sleeping dog",
                 cls="inline-formatted-content"
@@ -243,6 +263,7 @@ overlapping_same_area_test_data = (
         cls="post-body"
     )
 )
+
 
 overlapping_same_start_different_end_data = (
     [
@@ -268,16 +289,29 @@ overlapping_same_start_different_end_data = (
                             "brown ",
                             style="color: #964B00;",
                             cls="inline-color"
-
                         ),
+                        href="https://www.youtube.com/watch?v=jofNR_WkoCE",
+                        cls="inline-link"
+                    ),
+                    cls="inline-bold"
+                ),
+
+                tags.b(
+                    tags.a(
                         "fox jumped",
                         href="https://www.youtube.com/watch?v=jofNR_WkoCE",
                         cls="inline-link"
                     ),
+                    cls="inline-bold"
+                ),
+
+                tags.b(
                     " over the ",
                     cls="inline-bold"
                 ),
+
                 "lazy dog",
+
                 cls="inline-formatted-content"
             ),
             cls="text-block indented inline-formatted-block"
@@ -285,6 +319,7 @@ overlapping_same_start_different_end_data = (
         cls="post-body"
     )
 )
+
 
 interrupted_same_indices_overlapping = (
     [
@@ -305,37 +340,35 @@ interrupted_same_indices_overlapping = (
         tags.blockquote(
             tags.span(
                 "Th",
-                tags.a(
-                    "e ",
-                    tags.span(
-                        tags.i(
-                            tags.small(
+                tags.a("e ", cls="inline-link", href="https://www.youtube.com/watch?v=dQw4w9WgXcQ"),
+                tags.i(
+                    tags.small(
+                        tags.a(
+                            tags.span(
                                 "brow",
-                                cls="inline-small"
+                                style="color: #964B00;",
+                                cls="inline-color"
                             ),
-                            cls="inline-italics"
+                            cls="inline-link",
+                            href="https://www.youtube.com/watch?v=dQw4w9WgXcQ"
                         ),
-                        style="color: #964B00;",
-                        cls="inline-color",
+                        cls="inline-small"
                     ),
-                    href="https://www.youtube.com/watch?v=dQw4w9WgXcQ",
-                    cls="inline-link"
+                    cls="inline-italics"
                 ),
 
-                tags.span(
-                    tags.i(
-                        tags.small(
+                tags.i(
+                    tags.small(
+                        tags.span(
                             "n fox jumped over",
-                            cls="inline-small"
+                            style="color: #964B00;",
+                            cls="inline-color"
                         ),
-                        cls="inline-italics"
+                        cls="inline-small"
                     ),
-                    style="color: #964B00;",
-                    cls="inline-color",
+                    cls="inline-italics"
                 ),
-
                 " the lazy dog",
-
                 cls="inline-formatted-content"
             ),
             cls="text-block indented inline-formatted-block"
@@ -343,6 +376,7 @@ interrupted_same_indices_overlapping = (
         cls="post-body"
     )
 )
+
 
 interrupted_overlap_test = (
     [
@@ -362,19 +396,20 @@ interrupted_overlap_test = (
         tags.h1(
             tags.span(
                 "The b",
-                tags.small(
-                    "row",
-                    tags.s(
-                        "n ",
+                tags.small("row", cls="inline-small"),
+                tags.s(tags.small("n ", cls="inline-small"), cls="inline-strikethrough"),
+                tags.s(
+                    tags.small(
                         tags.span(
                             "fox",
                             style="color: #964B00;",
                             cls="inline-color",
                         ),
-                        cls="inline-strikethrough"
+                        cls="inline-small"
                     ),
-                    cls="inline-small"
+                    cls="inline-strikethrough"
                 ),
+
                 tags.s(
                     tags.span(
                         " jump",
@@ -400,6 +435,7 @@ interrupted_overlap_test = (
     )
 )
 
+
 interrupted_overlap_test_2 = (
     [
         {
@@ -418,44 +454,93 @@ interrupted_overlap_test_2 = (
     ], tags.div(
         tags.h1(
             tags.span(
-                tags.span(
-                    tags.b(
-                        "The b",
+                tags.b(tags.span("The b", style="color: #964B00;", cls="inline-color"), cls="inline-bold"),
+                tags.b(
+                    tags.small(
+                        tags.span(
+                            "row", 
+                            style="color: #964B00;",
+                            cls="inline-color"  
+                        ),
+                        cls="inline-small",
+                    ),
+                    cls="inline-bold"
+                ),
+                tags.b(
+                    tags.s(
                         tags.small(
-                            "row",
-                            tags.s(
-                                "n ",
-                                tags.i(
-                                    "fox",
-                                    cls="inline-italics"
-                                ),
-                                cls="inline-strikethrough"
+                            tags.span(
+                                "n ", 
+                                style="color: #964B00;",
+                                cls="inline-color"  
                             ),
                             cls="inline-small",
                         ),
-
-                        tags.s(
-                            tags.i(
-                                " jumped",
-                                cls="inline-italics",
-                            ),
-                            cls="inline-strikethrough",
-                        ),
-
-                        tags.i(
-                            " over",
-                            cls="inline-italics",
-                        ),
-
-                        " the ",
-
-                        cls="inline-bold",
+                        cls="inline-strikethrough"
                     ),
-
-                    "laz",
-                    cls="inline-color",
-                    style="color: #964B00;",
+                    cls="inline-bold"
                 ),
+
+                tags.b(
+                    tags.i(
+                        tags.s(
+                            tags.small(
+                                tags.span(
+                                    "fox", 
+                                    style="color: #964B00;",
+                                    cls="inline-color"  
+                                ),
+                                cls="inline-small",
+                            ),
+                            cls="inline-strikethrough"
+                        ),
+                        cls="inline-italics"
+                    ),
+                    cls="inline-bold"
+                ),
+
+                tags.b(
+                    tags.i(
+                        tags.s(
+                            tags.span(
+                                " jumped", 
+                                style="color: #964B00;",
+                                cls="inline-color"  
+                            ),
+                            cls="inline-strikethrough"
+                        ),
+                        cls="inline-italics"
+                    ),
+                    cls="inline-bold"
+                ),
+
+                tags.b(
+                    tags.i(
+                        tags.span(
+                            " over", 
+                            style="color: #964B00;",
+                            cls="inline-color"  
+                        ),
+                        cls="inline-italics"
+                    ),
+                    cls="inline-bold"
+                ),
+
+                tags.b(
+                    tags.span(
+                        " the ", 
+                        style="color: #964B00;",
+                        cls="inline-color"  
+                    ),
+                    cls="inline-bold"
+                ),
+
+                tags.span(
+                    "laz", 
+                    style="color: #964B00;",
+                    cls="inline-color"  
+                ),
+
                 "y dog",
 
                 cls="inline-formatted-content"
@@ -465,6 +550,7 @@ interrupted_overlap_test_2 = (
         cls="post-body"
     )
 )
+
 
 interrupted_overlap_test_3 = (
     [
@@ -486,65 +572,59 @@ interrupted_overlap_test_3 = (
         tags.h1(
             tags.span(
                 "The b",
-                tags.small(
-                    "row",
-                    tags.s(
-                        "n ",
-                        tags.i(
-                            "fo",
-                            tags.b(
-                                "x",
-                                cls="inline-bold"
-                            ),
-                            cls="inline-italics"
-                        ),
-                        cls="inline-strikethrough"
-                    ),
-                    cls="inline-small"
-                ),
-                tags.i(
-                    tags.s(
-                        tags.b(
+                tags.small("row", cls="inline-small"),
+                tags.s(tags.small("n ", cls="inline-small"), cls="inline-strikethrough"),
+                tags.i(tags.s(tags.small("fo", cls="inline-small"), cls="inline-strikethrough"), cls="inline-italics"),
+                tags.b(tags.i(tags.s(tags.small("x", cls="inline-small"), cls="inline-strikethrough"), cls="inline-italics"), cls="inline-bold"),
+                tags.b(
+                    tags.i(
+                        tags.s(
                             " ",
+                            cls="inline-strikethrough"
+                        ),
+                        cls="inline-italics"
+                    ),
+                    cls="inline-bold"
+                ),
+
+                tags.b(
+                    tags.i(
+                        tags.s(
                             tags.span(
                                 "jumped",
                                 style="color: #964B00;",
-                                cls="inline-color",
+                                cls="inline-color"
                             ),
-                            cls="inline-bold"
+                            cls="inline-strikethrough"
                         ),
-                        cls="inline-strikethrough"
+                        cls="inline-italics"
                     ),
+                    cls="inline-bold"
+                ),
 
-                    tags.b(
+                tags.b(
+                    tags.i(
                         tags.span(
                             " over",
                             style="color: #964B00;",
-                            cls="inline-color",
+                            cls="inline-color"
                         ),
-                        cls="inline-bold"
+                        cls="inline-italics"
                     ),
-
-                    cls="inline-italics"
+                    cls="inline-bold"
                 ),
 
                 tags.b(
                     tags.span(
                         " th",
                         style="color: #964B00;",
-                        cls="inline-color",
+                        cls="inline-color"
                     ),
                     cls="inline-bold"
                 ),
 
-                tags.span(
-                    "e laz",
-                    style="color: #964B00;",
-                    cls="inline-color",
-                ),
-
+                tags.span("e laz", style="color: #964B00;", cls="inline-color"),
                 "y dog",
-
                 cls="inline-formatted-content"
             ),
             cls="text-block heading1 inline-formatted-block"
@@ -574,72 +654,85 @@ interrupted_overlap_test_4 = (
         tags.h1(
             tags.span(
                 "The b",
-                tags.small(
-                    "row",
-                    tags.s(
-                        "n ",
-                        tags.i(
-                            "fo",
-                            tags.b(
-                                "x",
-                                cls="inline-bold"
-                            ),
-                            cls="inline-italics"
+                tags.small("row", cls="inline-small"),
+                tags.s(tags.small("n ", cls="inline-small"), cls="inline-strikethrough"),
+                tags.i(tags.s(tags.small("fo", cls="inline-small"),cls="inline-strikethrough"), cls="inline-italics"),
+                tags.b(
+                    tags.i(
+                        tags.s(
+                            tags.small("x", cls="inline-small"),
+                            cls="inline-strikethrough"
                         ),
-                        cls="inline-strikethrough"
+                        cls="inline-italics"
                     ),
-                    cls="inline-small"
+                    cls="inline-bold"
                 ),
-                tags.i(
-                    tags.s(
-                        tags.b(
+                tags.b(
+                    tags.i(
+                        tags.s(
                             " ",
+                            cls="inline-strikethrough"
+                        ),
+                        cls="inline-italics"
+                    ),
+                    cls="inline-bold"
+                ),
+                tags.b(
+                    tags.i(
+                        tags.s(
                             tags.span(
                                 "jumped",
                                 style="color: #964B00;",
-                                cls="inline-color",
+                                cls="inline-color"
                             ),
-                            cls="inline-bold"
+                            cls="inline-strikethrough"
                         ),
-                        cls="inline-strikethrough"
+                        cls="inline-italics"
                     ),
+                    cls="inline-bold"
+                ),
 
-                    tags.b(
+                tags.b(
+                    tags.i(
                         tags.span(
                             " over",
                             style="color: #964B00;",
-                            cls="inline-color",
+                            cls="inline-color"
                         ),
-                        cls="inline-bold"
+                        cls="inline-italics"
                     ),
-
-                    cls="inline-italics"
+                    cls="inline-bold"
                 ),
 
                 tags.b(
                     tags.span(
                         " th",
                         style="color: #964B00;",
-                        cls="inline-color",
+                        cls="inline-color"
                     ),
                     cls="inline-bold"
                 ),
 
                 tags.span(
                     "e lazy ",
+                    style="color: #964B00;",
+                    cls="inline-color"
+                ),
+
+                tags.span(
                     tags.span(
                         "d",
                         style="color: #FFFFFF;",
-                        cls="inline-color",
+                        cls="inline-color"
                     ),
                     style="color: #964B00;",
-                    cls="inline-color",
+                    cls="inline-color"
                 ),
 
                 tags.span(
                     "og",
                     style="color: #FFFFFF;",
-                    cls="inline-color",
+                    cls="inline-color"
                 ),
 
                 cls="inline-formatted-content"
@@ -649,6 +742,7 @@ interrupted_overlap_test_4 = (
         cls="post-body"
     )
 )
+
 
 interrupted_overlap_test_5 = (
     [
@@ -668,40 +762,51 @@ interrupted_overlap_test_5 = (
         tags.h1(
             tags.span(
                 "The b",
-                tags.small(
-                    "row",
+                tags.small("row", cls="inline-small"),
+                tags.s(
+                    tags.small("n ", cls="inline-small"),
+                    cls="inline-strikethrough"
+                ),
+                tags.i(
                     tags.s(
-                        "n ",
-                        tags.i(
-                            "fo",
-                            tags.b(
-                                "x",
-                                cls="inline-bold"
-                            ),
-                            cls="inline-italics"
-                        ),
+                        tags.small("fo", cls="inline-small"),
                         cls="inline-strikethrough"
                     ),
-                    cls="inline-small"
+                    cls="inline-italics"
+                ),
+                tags.b(
+                    tags.i(
+                        tags.s(
+                            tags.small("x", cls="inline-small"),
+                            cls="inline-strikethrough"
+                        ),
+                        cls="inline-italics"
+                    ),
+                    cls="inline-bold"
+                ),
+
+                tags.b(
+                    tags.i(
+                        tags.s(
+                            " jumped",
+                            cls="inline-strikethrough"
+                        ),
+                        cls="inline-italics"
+                    ),
+                    cls="inline-bold"
+                ),
+
+                tags.b(
+                    tags.i(
+                        " o",
+                        cls="inline-italics"
+                    ),
+                    cls="inline-bold"
                 ),
 
                 tags.i(
-                    tags.s(
-                        tags.b(
-                            " jumped",
-                            cls="inline-bold"
-                        ),
-                        cls="inline-strikethrough"
-                    ),
-
-                    tags.b(
-                        " o",
-                        cls="inline-bold"
-                    ),
-
                     "ver",
-
-                    cls="inline-italics",
+                    cls="inline-italics"
                 ),
 
                 " the lazy dog",
@@ -713,6 +818,7 @@ interrupted_overlap_test_5 = (
         cls="post-body"
     )
 )
+
 
 interrupted_overlap_test_6 = (
     [
@@ -735,61 +841,97 @@ interrupted_overlap_test_6 = (
         tags.h1(
             tags.span(
                 "The b",
-                tags.small(
-                    "row",
+                tags.small("row", cls="inline-small"),
+                tags.s(tags.small("n ", cls="inline-small"), cls="inline-strikethrough"),
+                tags.i(
                     tags.s(
-                        "n ",
-                        tags.i(
+                        tags.small(
                             tags.a(
                                 tags.span(
                                     "fo",
-                                    tags.b(
-                                        "x",
-                                        cls="inline-bold"
-                                    ),
                                     style="color: #FFFFFF;",
                                     cls="inline-color"
                                 ),
                                 href="example.com",
-                                cls="inline-link",
+                                cls="inline-link"
                             ),
-                            cls="inline-italics"
+                            cls="inline-small"
                         ),
                         cls="inline-strikethrough"
                     ),
-                    cls="inline-small"
+                    cls="inline-italics"
+                ),
+                tags.b(
+                    tags.i(
+                        tags.s(
+                            tags.small(
+                                tags.a(
+                                    tags.span(
+                                        "x",
+                                        style="color: #FFFFFF;",
+                                        cls="inline-color"
+                                    ),
+                                    href="example.com",
+                                    cls="inline-link"
+                                ),
+                                cls="inline-small"
+                            ),
+                            cls="inline-strikethrough"
+                        ),
+                        cls="inline-italics"
+                    ),
+                    cls="inline-bold"
+                ),
+
+                tags.b(
+                    tags.i(
+                        tags.s(
+                            tags.a(
+                                tags.span(
+                                    " jumped",
+                                    style="color: #FFFFFF;",
+                                    cls="inline-color"
+                                ),
+                                href="example.com",
+                                cls="inline-link"
+                            ),
+                            cls="inline-strikethrough"
+                        ),
+                        cls="inline-italics"
+                    ),
+                    cls="inline-bold"
+                ),
+
+                tags.b(
+                    tags.i(
+                        tags.a(
+                            tags.span(
+                                " o",
+                                style="color: #FFFFFF;",
+                                cls="inline-color"
+                            ),
+                            href="example.com",
+                            cls="inline-link"
+                        ),
+                        cls="inline-italics"
+                    ),
+                    cls="inline-bold"
                 ),
 
                 tags.i(
                     tags.a(
                         tags.span(
-                            tags.s(
-                                tags.b(
-                                    " jumped",
-                                    cls="inline-bold"
-                                ),
-                                cls="inline-strikethrough"
-                            ),
-
-                            tags.b(
-                                " o",
-                                cls="inline-bold"
-                            ),
-
                             "ver",
-
                             style="color: #FFFFFF;",
                             cls="inline-color"
                         ),
                         href="example.com",
-                        cls="inline-link",
+                        cls="inline-link"
                     ),
-
                     cls="inline-italics"
                 ),
 
                 " the lazy dog",
-
                 cls="inline-formatted-content"
             ),
             cls="text-block heading1 inline-formatted-block"
@@ -797,6 +939,7 @@ interrupted_overlap_test_6 = (
         cls="post-body"
     )
 )
+
 
 same_index_with_other_overlap_test = (
     [
@@ -817,23 +960,28 @@ same_index_with_other_overlap_test = (
     tags.div(
         tags.h1(
             tags.span(
-                tags.span(
-                    tags.b(
+                tags.b(
+                    tags.span(
                         "The brown",
-                        cls="inline-bold"
+                        style="color: #FFFFFF;",
+                        cls="inline-color"
                     ),
-                    style="color: #FFFFFF;",
-                    cls="inline-color",
+                    cls="inline-bold",
                 ),
                 " ",
                 tags.span(
                     "fox j",
-                    tags.i(
-                        "umped",
-                        cls="inline-italics"
-                    ),
                     style="color: #964B00;",
                     cls="inline-color",
+                ),
+
+                tags.i(
+                    tags.span(
+                        "umped",
+                        style="color: #964B00;",
+                        cls="inline-color"
+                    ),
+                    cls="inline-italics",
                 ),
 
                 tags.i(
@@ -989,6 +1137,7 @@ link_url_handler_test_data = (
     )
 )
 
+
 excessively_out_of_bounds_end_single_op_test = (
     [{
         "type": "text",
@@ -1040,7 +1189,7 @@ excessively_out_of_bounds_end_multiple_op_test = (
     tags.div(
         tags.blockquote(
             tags.span(
-                tags.i(tags.b("some text", cls="inline-bold"), cls="inline-italics"),
+                tags.b(tags.i("some text", cls="inline-italics"), cls="inline-bold"),
                 cls="inline-formatted-content"
             ),
             cls="text-block indented inline-formatted-block"
@@ -1075,7 +1224,7 @@ excessively_out_of_bounds_end_overlap_test = (
     tags.div(
         tags.blockquote(
             tags.span(
-                tags.i(tags.b("some text", cls="inline-bold"), cls="inline-italics"),
+                tags.b(tags.i("some text", cls="inline-italics"), cls="inline-bold"),
                 cls="inline-formatted-content"
             ),
             cls="text-block indented inline-formatted-block"
@@ -1083,6 +1232,7 @@ excessively_out_of_bounds_end_overlap_test = (
         cls="post-body"
     )
 )
+
 
 excessively_out_of_bounds_end_multiple_op_differing_start_test = (
     [{
@@ -1109,7 +1259,8 @@ excessively_out_of_bounds_end_multiple_op_differing_start_test = (
     tags.div(
         tags.blockquote(
             tags.span(
-                tags.i("some ", tags.b("text", cls="inline-bold"), cls="inline-italics"),
+                tags.i("some ", cls="inline-italics"),
+                tags.b(tags.i("text", cls="inline-italics"),cls="inline-bold"),
                 cls="inline-formatted-content"
             ),
             cls="text-block indented inline-formatted-block"

--- a/tests/inline/inline_formatting_data.py
+++ b/tests/inline/inline_formatting_data.py
@@ -16,7 +16,7 @@ standard_test = (
     [
         objects.text_block.TextBlock(
             text="some small text",
-            inline_formatting=[objects.inline.Standard(type=objects.inline.FMTTypes.SMALL, start=5, end=10)],
+            inline_formatting=[objects.inline.StyleInterval(start=5, end=10, instructions=[objects.inline.Instruction(objects.inline.FMTTypes.SMALL)])],
         )
     ],
     tags.div(
@@ -51,11 +51,15 @@ link_test = (
         objects.text_block.TextBlock(
             text="Found this link for you",
             inline_formatting=[
-                objects.inline.Link(
-                    type=objects.inline.FMTTypes.LINK,
+                objects.inline.StyleInterval(
                     start=6,
                     end=10,
-                    url="https://www.nasa.gov",
+                    instructions=[
+                        objects.inline.LinkInstruction(
+                            type_=objects.inline.FMTTypes.LINK,
+                            url="https://www.nasa.gov",
+                        )
+                    ],
                 )
             ],
         )
@@ -73,6 +77,8 @@ link_test = (
         cls="post-body",
     ),
 )
+
+
 mention_test = (
     {
         "content": [
@@ -98,13 +104,17 @@ mention_test = (
         objects.text_block.TextBlock(
             text="Shout out to @david",
             inline_formatting=[
-                objects.inline.Mention(
-                    type=objects.inline.FMTTypes.MENTION,
+                objects.inline.StyleInterval(
                     start=13,
                     end=19,
-                    blog_uuid="t:123456abcdf",
-                    blog_name="david",
-                    blog_url="https://davidslog.com/",
+                    instructions=[
+                        objects.inline.MentionInstruction(
+                            type_=objects.inline.FMTTypes.MENTION,
+                            blog_uuid="t:123456abcdf",
+                            blog_name="david",
+                            blog_url="https://davidslog.com/",
+                        )
+                    ],
                 )
             ],
         )
@@ -122,6 +132,7 @@ mention_test = (
     ),
 )
 
+
 color_test = (
     {
         "content": [
@@ -136,8 +147,17 @@ color_test = (
         objects.text_block.TextBlock(
             text="Celebrate Pride Month",
             inline_formatting=[
-                objects.inline.Color(type=objects.inline.FMTTypes.COLOR, start=10, end=15, hex="#ff492f")
-            ],
+                objects.inline.StyleInterval(
+                    start=10,
+                    end=15,
+                    instructions=[
+                        objects.inline.ColorInstruction(
+                            type_=objects.inline.FMTTypes.COLOR,
+                            hex="#ff492f"
+                        )
+                    ],
+                )
+            ]
         )
     ],
     tags.div(
@@ -154,136 +174,3 @@ color_test = (
     ),
 )
 
-test_overlapping = (
-    {
-        "content": [
-            {
-                "type": "text",
-                "text": "supercalifragilisticexpialidocious",
-                "formatting": [
-                    {"start": 0, "end": 20, "type": "bold"},
-                    {"start": 9, "end": 34, "type": "italic"},
-                ],
-            }
-        ]
-    },
-    [
-        objects.text_block.TextBlock(
-            text="supercalifragilisticexpialidocious",
-            inline_formatting=[
-                objects.inline.Standard(
-                    type=objects.inline.FMTTypes.BOLD,
-                    start=0,
-                    end=20,
-                ),
-                objects.inline.Standard(
-                    type=objects.inline.FMTTypes.ITALIC,
-                    start=9,
-                    end=34,
-                ),
-            ],
-        ),
-    ],
-    tags.div(
-        tags.p(
-            tags.span(
-                tags.b(
-                    "supercali",
-                    tags.i("fragilistic", cls="inline-italics"),
-                    cls="inline-bold",
-                ),
-                tags.i("expialidocious", cls="inline-italics"),
-                cls="inline-formatted-content",
-            ),
-            cls="text-block",
-        ),
-        cls="post-body",
-    ),
-)
-
-test_total_overlapping = (
-    {
-        "content": [
-            {
-                "type": "text",
-                "text": "supercalifragilisticexpialidocious",
-                "formatting": [
-                    {"start": 0, "end": 34, "type": "bold"},
-                    {"start": 0, "end": 34, "type": "italic"},
-                    {"start": 0, "end": 34, "type": "small"},
-                    {"start": 0, "end": 34, "type": "strikethrough"},
-                    {"start": 0, "end": 34, "type": "link",
-                     "url": "https://en.wiktionary.org/wiki/supercalifragilisticexpialidocious"},
-                ],
-            }
-        ]
-    },
-    [
-        objects.text_block.TextBlock(
-            text="supercalifragilisticexpialidocious",
-            inline_formatting=[
-                objects.inline.TotalOverlaps(
-                    type=[
-                        objects.inline.Standard(
-                            type=objects.inline.FMTTypes.BOLD,
-                            start=0,
-                            end=34,
-                        ),
-                        objects.inline.Standard(
-                            type=objects.inline.FMTTypes.ITALIC,
-                            start=0,
-                            end=34,
-                        ),
-                        objects.inline.Standard(
-                            type=objects.inline.FMTTypes.SMALL,
-                            start=0,
-                            end=34,
-                        ),
-                        objects.inline.Standard(
-                            type=objects.inline.FMTTypes.STRIKETHROUGH,
-                            start=0,
-                            end=34,
-                        ),
-                        objects.inline.Link(
-                            type=objects.inline.FMTTypes.LINK,
-                            start=0,
-                            end=34,
-                            url="https://en.wiktionary.org/wiki/supercalifragilisticexpialidocious",
-                        )
-                    ],
-
-                    start=0,
-                    end=34
-                )
-
-            ],
-        ),
-    ],
-    tags.div(
-        tags.p(
-            tags.span(
-                tags.b(
-                    tags.i(
-                        tags.small(
-                            tags.s(
-                                tags.a(
-                                    "supercalifragilisticexpialidocious",
-                                    href="https://en.wiktionary.org/wiki/supercalifragilisticexpialidocious",
-                                    cls="inline-link"
-                                ),
-                                cls="inline-strikethrough",
-                            ),
-                            cls="inline-small",
-                        ),
-                        cls="inline-italics"
-                    ),
-
-                    cls="inline-bold",
-                ),
-                cls="inline-formatted-content",
-            ),
-            cls="text-block",
-        ),
-        cls="post-body",
-    ),
-)

--- a/tests/inline/test_inline_format.py
+++ b/tests/inline/test_inline_format.py
@@ -34,10 +34,6 @@ def test_color_formatting_render():
     helper_function(color_test[0], color_test[2])
 
 
-def test_overlapping_render():
-    helper_function(test_overlapping[0], test_overlapping[2])
-
-
 # Exclusive formatting tests below:
 # -------------------------------------------------------------
 #

--- a/tests/inline/test_inline_parse.py
+++ b/tests/inline/test_inline_parse.py
@@ -38,11 +38,3 @@ def test_mention_formatting_parse():
 
 def test_color_formatting_parse():
     helper_function(color_test[0], color_test[1])
-
-
-def test_overlapping_parse():
-    helper_function(test_overlapping[0], test_overlapping[1])
-
-
-def test_total_overlapping_parse():
-    helper_function(test_total_overlapping[0], test_total_overlapping[1])

--- a/tests/text_block/example_text_block_data.py
+++ b/tests/text_block/example_text_block_data.py
@@ -436,8 +436,10 @@ top_level_list_with_children_merging_test_data = (
             text="I've got a bunch of links for you!",
             subtype=objects.text_block.Subtypes.HEADING1,
             inline_formatting=[
-                objects.inline.Standard(start=0, end=34, type=objects.inline.FMTTypes.BOLD)
-            ]
+                objects.inline.StyleInterval(
+                    start=0, end=34, instructions=[objects.inline.Instruction(objects.inline.FMTTypes.BOLD)]
+                )
+            ],
         ),
         objects.text_block.TextBlock(text="Interesting stuff",
                                      subtype=objects.text_block.Subtypes.HEADING2),
@@ -455,36 +457,48 @@ top_level_list_with_children_merging_test_data = (
                                 objects.text_block.TextBlock(
                                     text="NASA",
                                     inline_formatting=[
-                                        objects.inline.Link(
+                                        objects.inline.StyleInterval(
                                             start=0,
                                             end=4,
-                                            type=objects.inline.FMTTypes.LINK,
-                                            url="https://www.nasa.gov",
-                                        ),
+                                            instructions=[
+                                                objects.inline.LinkInstruction(
+                                                    type_=objects.inline.FMTTypes.LINK,
+                                                    url="https://www.nasa.gov",
+                                                )
+                                            ],
+                                        )
                                     ],
                                     subtype=objects.text_block.Subtypes.UNORDERED_LIST_ITEM,
                                 ),
                                 objects.text_block.TextBlock(
                                     text="ESA",
                                     inline_formatting=[
-                                        objects.inline.Link(
+                                        objects.inline.StyleInterval(
                                             start=0,
                                             end=3,
-                                            type=objects.inline.FMTTypes.LINK,
-                                            url="https://www.esa.int/",
-                                        ),
-                                    ],
+                                            instructions=[
+                                                objects.inline.LinkInstruction(
+                                                    type_=objects.inline.FMTTypes.LINK,
+                                                    url="https://www.esa.int/",
+                                                )
+                                            ],
+                                        )
+                                    ],                                    
                                     subtype=objects.text_block.Subtypes.UNORDERED_LIST_ITEM,
                                 ),
                                 objects.text_block.TextBlock(
                                     text="SpaceX",
                                     inline_formatting=[
-                                        objects.inline.Link(
+                                        objects.inline.StyleInterval(
                                             start=0,
                                             end=6,
-                                            type=objects.inline.FMTTypes.LINK,
-                                            url="https://www.spacex.com/",
-                                        ),
+                                            instructions=[
+                                                objects.inline.LinkInstruction(
+                                                    type_=objects.inline.FMTTypes.LINK,
+                                                    url="https://www.spacex.com/",
+                                                )
+                                            ],
+                                        )
                                     ],
                                     subtype=objects.text_block.Subtypes.UNORDERED_LIST_ITEM,
                                 ),
@@ -502,11 +516,15 @@ top_level_list_with_children_merging_test_data = (
                                 objects.text_block.TextBlock(
                                     text="Github",
                                     inline_formatting=[
-                                        objects.inline.Link(
+                                        objects.inline.StyleInterval(
                                             start=0,
                                             end=6,
-                                            type=objects.inline.FMTTypes.LINK,
-                                            url="https://www.github.com/",
+                                            instructions=[
+                                                objects.inline.LinkInstruction(
+                                                    type_=objects.inline.FMTTypes.LINK,
+                                                    url="https://www.github.com/",
+                                                )
+                                            ],
                                         ),
                                     ],
                                     subtype=objects.text_block.Subtypes.UNORDERED_LIST_ITEM,
@@ -514,11 +532,15 @@ top_level_list_with_children_merging_test_data = (
                                 objects.text_block.TextBlock(
                                     text="Gitlab",
                                     inline_formatting=[
-                                        objects.inline.Link(
+                                        objects.inline.StyleInterval(
                                             start=0,
                                             end=6,
-                                            type=objects.inline.FMTTypes.LINK,
-                                            url="https://about.gitlab.com/",
+                                            instructions=[
+                                                objects.inline.LinkInstruction(
+                                                    type_=objects.inline.FMTTypes.LINK,
+                                                    url="https://about.gitlab.com/",
+                                                )
+                                            ],
                                         ),
                                     ],
                                     subtype=objects.text_block.Subtypes.UNORDERED_LIST_ITEM,


### PR DESCRIPTION
Closes #4

This PR simplifies the convoluted method in which inline formatting was handled.

By splitting the overlapping inline formatting intervals into discrete slices that signifies how to style that slice, the logic for inline formatting can be simplified to a single loop instead of the recursive series of checks and dozens of while loops.

This improves performance, code clarity, and fixes some long-standing bugs in the renderer.

The caveat however is that the resulting HTML now has the chance to be much larger than before. This should be addressed as soon as possible.

Also fixes #2 albeit unintentionally 