### PR TITLE
Loosen dependencies' version requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 requires-python = ">=3.10"
-dependencies = ["dominate==2.8.0", "intervaltree==3.1.0"]
+dependencies = ["dominate>=2.8.0", "intervaltree>=3.1.0"]
 
 [project.optional-dependencies]
 dev = ["pytest==7.4.2", "prettyprinter==0.18.0", "freezegun==1.4.0"]


### PR DESCRIPTION
This commit allows users of npf-renderer to install dependency versions greater than or equal to the version we need.

This way applications can have greater control over their dependencies