### PR TITLE
Handle when value is falsey in get compare

### DIFF
--- a/src/npf_renderer/format/base.py
+++ b/src/npf_renderer/format/base.py
@@ -584,7 +584,11 @@ class Formatter(helpers.CursorIterator):
 
                         row_tag = dominate.tags.div(cls="layout-row")
 
-                        if self.truncate_posts and layout.truncate_after and (block_index > layout.truncate_after):
+                        if (
+                            self.truncate_posts
+                            and layout.truncate_after is not None
+                            and (block_index > layout.truncate_after)
+                        ):
                             if row_attachment_point == self.post:
                                 row_attachment_point = self.create_truncation_details_box()
                                 self.post.add(row_attachment_point)

--- a/src/npf_renderer/parse/base.py
+++ b/src/npf_renderer/parse/base.py
@@ -1,0 +1,44 @@
+from typing import Optional
+from .. import helpers
+
+
+class BaseParser(helpers.CursorIterator):
+    def __init__(self, content):
+        super().__init__(content)
+        self.parsed_result = []
+
+    def get(self, key, target=None):
+        """Fetches the value that matches the given key from the current block
+
+        Assumes that the current item in iteration is subscriptable
+        """
+        if not target:
+            target = self.current
+
+        if key in target:
+            return target[key]
+
+        return None
+
+    def get_or(self, *keys, target=None):
+        """Fetches the first value that matches the given keys from the current block
+
+        Assumes that the current item in iteration is subscriptable
+        """
+        for key in keys:
+            value = self.get(key, target)
+
+            if value is not None:
+                return value
+
+        return None
+
+    def __parse_next(self):
+        pass
+
+    def parse(self):
+        """Begins the parsing chain and returns the final list of parsed objects"""
+        while self.next():
+            self.parsed_result.append(self.__parse_next())
+
+        return self.parsed_result

--- a/src/npf_renderer/parse/layout_parse.py
+++ b/src/npf_renderer/parse/layout_parse.py
@@ -1,9 +1,9 @@
-from . import misc
+from . import misc, base
 from .. import helpers
 from .. import objects
 
 
-class LayoutParser(helpers.CursorIterator):
+class LayoutParser(base.BaseParser):
     def __init__(self, layouts):
         super().__init__(layouts)
 
@@ -28,7 +28,7 @@ class LayoutParser(helpers.CursorIterator):
                 self._ask_indices.extend(indices)
             elif self.current["type"] == "rows":
                 rows = []
-                truncate_after = self.current.get("truncateAfter") or self.current.get("truncate_after")
+                truncate_after = self.get_or("truncateAfter", "truncate_after")
 
                 for row in self.current["display"]:
                     indices = [index for index in row["blocks"] if index not in self._ask_indices]

--- a/tests/layouts/example_layout_data.py
+++ b/tests/layouts/example_layout_data.py
@@ -98,6 +98,7 @@ basic_rows_layout_with_truncate_example = (
     ),
 )
 
+
 basic_rows_layout_with_truncate_example_disabled_truncation = (
     basic_rows_layout_with_truncate_example[0],
     (
@@ -175,6 +176,48 @@ basic_rows_layout_with_truncate_at_start_example_disabled_truncation = (
                 cls="layout-row",
             ),
             dominate.tags.div(generate_image_block_html(4, 2), generate_image_block_html(5, 2), cls="layout-row"),
+            cls="post-body",
+        )
+    ),
+)
+
+
+rows_layout_truncate_after_0th_block = (
+    {
+        "layouts": [
+            {
+                "type": "rows",
+                "display": [
+                    {"blocks": [0]},
+                    {"blocks": [1, 2, 3]},
+                    {"blocks": [4, 5]},
+                ],
+                "truncate_after": 0,
+            }
+        ]
+    },
+    [
+        layouts.Rows(
+            rows=[layouts.RowLayout([0]), layouts.RowLayout([1, 2, 3]), layouts.RowLayout([4, 5])], truncate_after=0
+        )
+    ],
+    (
+        dominate.tags.div(
+            dominate.tags.div(
+                dominate.tags.p("Hi there", cls="text-block"),
+                cls="layout-row",
+            ),
+            dominate.tags.details(
+                dominate.tags.summary("Read more"),
+                dominate.tags.div(
+                    generate_image_block_html(1, 3),
+                    generate_image_block_html(2, 3),
+                    generate_image_block_html(3, 3),
+                    cls="layout-row",
+                ),
+                dominate.tags.div(generate_image_block_html(4, 2), generate_image_block_html(5, 2), cls="layout-row"),
+                cls="layout-truncated",
+            ),
             cls="post-body",
         )
     ),

--- a/tests/layouts/test_layout_formatting.py
+++ b/tests/layouts/test_layout_formatting.py
@@ -49,6 +49,10 @@ def test_basic_layout_with_truncate_at_start_but_disabled_in_formatter_format():
     )
 
 
+def test_rows_layout_with_truncate_at_0th_block_format():
+    helper_function(data.rows_layout_truncate_after_0th_block[0], data.rows_layout_truncate_after_0th_block[2])
+
+
 def test_ask_layout_format():
     helper_function(data.layouts_with_ask_section[0], data.layouts_with_ask_section[2])
 

--- a/tests/layouts/test_layout_parse.py
+++ b/tests/layouts/test_layout_parse.py
@@ -39,6 +39,10 @@ def test_basic_layout_with_truncate_at_start_parse():
     )
 
 
+def test_rows_layout_with_truncate_at_0th_block_parse():
+    helper_function(data.rows_layout_truncate_after_0th_block[0], data.rows_layout_truncate_after_0th_block[1])
+
+
 def basic_rows_layout_with_camel_case_truncate_parse():
     helper_function(
         data.basic_rows_layout_with_camel_case_truncate_example[0],


### PR DESCRIPTION
Prior to this commit it was naively assumed that all values matched with .get from the dictionary will be truthy.

As such we just did a simple

val = d.get(k1) or d.get(k2)

to check for the existence of keys, which falters when the value given is actually falsey instead of truthy