### PR TITLE
Use aspect-ratio property to enforce aspect ratio

### DIFF
--- a/src/npf_renderer/format/base.py
+++ b/src/npf_renderer/format/base.py
@@ -90,12 +90,12 @@ class Formatter(helpers.CursorIterator):
 
         return unsupported
 
-    def _format_image(self, block, row_length=1, override_padding=None):
+    def _format_image(self, block, row_length=1, override_aspect_ratio=None):
         """Renders an ImageBlock into HTML"""
         figure = dominate.tags.figure(cls="image-block")
 
         image_container = image.format_image(
-            block, row_length, url_handler=self.url_handler, override_padding=override_padding, localizer=self.localizer
+            block, row_length, url_handler=self.url_handler, override_aspect_ratio=override_aspect_ratio, localizer=self.localizer
         )
 
         figure.add(image_container)
@@ -619,12 +619,12 @@ class Formatter(helpers.CursorIterator):
                                     continue
 
                                 images_in_row.append((item_index, item[0]))
-                                original_media_ratios.append(round((item[1].height / item[1].width) * 100, 4))
+                                original_media_ratios.append(round((item[1].width / item[1].height), 4))
 
-                            padding_ratio = min(original_media_ratios)
+                            aspect_ratio = max(original_media_ratios)
                             for index, render_instruction_args in images_in_row:
                                 row_items[index] = self._format_image(
-                                    *render_instruction_args, len(images_in_row), override_padding=padding_ratio
+                                    *render_instruction_args, len(images_in_row), override_aspect_ratio=aspect_ratio
                                 )
 
                         row_tag = dominate.tags.div(cls="layout-row")

--- a/src/npf_renderer/format/base.py
+++ b/src/npf_renderer/format/base.py
@@ -95,7 +95,11 @@ class Formatter(helpers.CursorIterator):
         figure = dominate.tags.figure(cls="image-block")
 
         image_container = image.format_image(
-            block, row_length, url_handler=self.url_handler, override_aspect_ratio=override_aspect_ratio, localizer=self.localizer
+            block,
+            row_length,
+            url_handler=self.url_handler,
+            override_aspect_ratio=override_aspect_ratio,
+            localizer=self.localizer,
         )
 
         figure.add(image_container)

--- a/src/npf_renderer/format/image.py
+++ b/src/npf_renderer/format/image.py
@@ -21,7 +21,7 @@ def format_image(
     image_block,
     row_length=1,
     url_handler=lambda url: url,
-    override_padding=None,
+    override_aspect_ratio=None,
     original_media=None,
     localizer: dict = {},
 ):
@@ -43,8 +43,8 @@ def format_image(
 
     processed_media_blocks = []
 
-    # Whether or not to preserve image space based on the aspect ratio
-    pad = True
+    # Whether images should follow a specific aspect ratio
+    with_aspect_ratio = True
 
     # Skip cropped images and attempt to fetch the media object with the
     # original dimensions to be used in the src= attribute
@@ -73,14 +73,14 @@ def format_image(
             # TODO find more examples of these bugged images and find a proper solution
             # Perhaps this could be a RenderDisclaimerError ? The post itself is fine. It is just weird.
             image_attributes["style"] = f"width: {original_media.width}px; height: {original_media.height}px;"
-            pad = False
+            with_aspect_ratio = False
 
-    if pad:
-        if override_padding:
-            container_attributes["style"] = f"padding-bottom: {override_padding}%;"
+    if with_aspect_ratio:
+        if override_aspect_ratio:
+            container_attributes["style"] = f"aspect-ratio: {override_aspect_ratio};"
         else:
             height, width = original_media.height, original_media.width
-            container_attributes["style"] = f"padding-bottom: {round((height / width) * 100, 4)}%;"
+            container_attributes["style"] = f"aspect-ratio: {round(width/height, 4)};"
 
     container = dominate.tags.div(**container_attributes)
 

--- a/src/npf_renderer/utils.py
+++ b/src/npf_renderer/utils.py
@@ -40,13 +40,9 @@ BASIC_LAYOUT_CSS = """
     position: relative;
 }
 
-.image-container img {
-  position: absolute;
-  left: 0;
-  top: 0;
-}
-
 .image-container img, .link-block img {
+  display: block;
+
   height: 100%;
   width: 100%;
   max-width: 100%;

--- a/tests/i18n/i18n_test_data.py
+++ b/tests/i18n/i18n_test_data.py
@@ -14,7 +14,7 @@ def generate_image_block_html(index, siblings):
                 alt="image",
             ),
             cls="image-container",
-            style="padding-bottom: 75.0%;",
+            style="aspect-ratio: 1.3333;",
         ),
     )
 

--- a/tests/image_block/image_block_test_data.py
+++ b/tests/image_block/image_block_test_data.py
@@ -90,7 +90,7 @@ basic_image_block = (
                     sizes="(max-width: 540px) 100vh, 540px",
                 ),
                 cls="image-container",
-                style="padding-bottom: 84.0625%;",
+                style="aspect-ratio: 1.1896;",
             ),
             dominate.tags.figcaption("I'm living my best life on earth.", cls="image-caption"),
             cls="image-block",
@@ -138,9 +138,10 @@ basic_gif_image_block = (
             sizes="(max-width: 540px) 100vh, 540px",
             alt="image",
         ),
-        container_style="padding-bottom: 80.0%;",
+        container_style="aspect-ratio: 1.25;",
     ),
 )
+
 
 image_block_with_color_attr = (
     [
@@ -181,7 +182,7 @@ image_block_with_color_attr = (
             sizes="(max-width: 540px) 100vh, 540px",
             alt="image",
         ),
-        container_style="padding-bottom: 83.8281%;",
+        container_style="aspect-ratio: 1.1929;",
     ),
 )
 
@@ -237,7 +238,7 @@ gif_image_block_with_poster = (
             sizes="(max-width: 540px) 100vh, 540px",
             alt="image",
         ),
-        container_style="padding-bottom: 80.0%;",
+        container_style="aspect-ratio: 1.25;",
     ),
 )
 
@@ -293,7 +294,7 @@ gif_image_block_with_post_attribution = (
             sizes="(max-width: 540px) 100vh, 540px",
             alt="image",
         ),
-        container_style="padding-bottom: 48.7395%;",
+        container_style="aspect-ratio: 2.0517;",
         figure_children=(
             dominate.tags.div(
                 dominate.tags.a(
@@ -360,7 +361,7 @@ gif_image_block_with_link_attribution = (
             sizes="(max-width: 540px) 100vh, 540px",
             alt="image",
         ),
-        container_style="padding-bottom: 140.0%;",
+        container_style="aspect-ratio: 0.7143;",
         figure_children=(
             dominate.tags.div(
                 dominate.tags.a(
@@ -488,7 +489,7 @@ image_block_with_app_attribution = (
                     alt="image",
                 ),
                 cls="image-container",
-                style="padding-bottom: 92.8205%;",
+                style="aspect-ratio: 1.0773;",
             ),
             cls="image-block",
         ),
@@ -511,7 +512,7 @@ image_block_with_app_attribution = (
                     alt="image",
                 ),
                 cls="image-container",
-                style="padding-bottom: 130.292%;",
+                style="aspect-ratio: 0.7675;",
             ),
             dominate.tags.div(
                 dominate.tags.a(
@@ -656,7 +657,7 @@ image_block_with_blog_attribution = (
                     alt="image",
                 ),
                 cls="image-container",
-                style="padding-bottom: 92.8205%;",
+                style="aspect-ratio: 1.0773;",
             ),
             cls="image-block",
         ),
@@ -679,7 +680,7 @@ image_block_with_blog_attribution = (
                     alt="image",
                 ),
                 cls="image-container",
-                style="padding-bottom: 130.292%;",
+                style="aspect-ratio: 0.7675;",
             ),
             dominate.tags.div(
                 dominate.tags.a(
@@ -805,7 +806,7 @@ image_block_with_unknown_attribution = (
                     alt="image",
                 ),
                 cls="image-container",
-                style="padding-bottom: 92.8205%;",
+                style="aspect-ratio: 1.0773;",
             ),
             cls="image-block",
         ),
@@ -828,7 +829,7 @@ image_block_with_unknown_attribution = (
                     alt="image",
                 ),
                 cls="image-container",
-                style="padding-bottom: 130.292%;",
+                style="aspect-ratio: 0.7675;",
             ),
             dominate.tags.div(
                 dominate.tags.p(
@@ -918,7 +919,7 @@ image_block_with_replaced_link = (
                     sizes="(max-width: 540px) 100vh, 540px",
                 ),
                 cls="image-container",
-                style="padding-bottom: 84.0625%;",
+                style="aspect-ratio: 1.1896;",
             ),
             dominate.tags.figcaption("I'm living my best life on earth.", cls="image-caption"),
             cls="image-block",
@@ -975,7 +976,7 @@ skips_cropped_image_block_test = (
                     sizes="(max-width: 540px) 100vh, 540px",
                 ),
                 cls="image-container",
-                style="padding-bottom: 150.0%;",
+                style="aspect-ratio: 0.6667;",
             ),
             cls="image-block",
         ),

--- a/tests/layouts/example_layout_data.py
+++ b/tests/layouts/example_layout_data.py
@@ -25,7 +25,7 @@ def generate_image_block_html(index, siblings):
                 alt="image",
             ),
             cls="image-container",
-            style="padding-bottom: 75.0%;",
+            style="aspect-ratio: 1.3333;",
         ),
     )
 


### PR DESCRIPTION
Replaces the padding-bottom absolute positioned CSS trick with the
aspect-ratio property.

aspect-ratio also helps prevents cls so this should just be a drop-in replacement assuming that photosets looks exactly the same